### PR TITLE
Keep the card expiration when the browser autofills it

### DIFF
--- a/packages/globalpayments-js/src/internal/gateways/genius/action-tokenize.ts
+++ b/packages/globalpayments-js/src/internal/gateways/genius/action-tokenize.ts
@@ -1,4 +1,5 @@
 import { IDictionary } from "../../lib/util";
+import parseExpiration from "../../lib/parse-expiration";
 
 export default async (url: string, env: string, data: IDictionary) => {
   const request: any = {
@@ -13,13 +14,11 @@ export default async (url: string, env: string, data: IDictionary) => {
     request.cvv = data["card-cvv"];
   }
 
-  if (
-    data["card-expiration"] &&
-    data["card-expiration"].indexOf(" / ") !== -1
-  ) {
-    const exp = data["card-expiration"].split(" / ");
-    request.expirationmonth = exp[0] || "";
-    request.expirationyear = (exp[1] || "").substr(2, 2);
+  const expiration = parseExpiration(data["card-expiration"]);
+
+  if (expiration) {
+    request.expirationmonth = expiration.month;
+    request.expirationyear = expiration.year;
   }
 
   if (data["card-holder-name"]) {

--- a/packages/globalpayments-js/src/internal/gateways/globalpayments/action-tokenize.ts
+++ b/packages/globalpayments-js/src/internal/gateways/globalpayments/action-tokenize.ts
@@ -1,4 +1,5 @@
 import { postMessage as pm } from "../../lib/post-message";
+import parseExpiration from "../../lib/parse-expiration";
 import { IDictionary } from "../../lib/util";
 
 import actionOnload from "./action-onload";
@@ -27,13 +28,11 @@ export default async (url: string, env: string, data: IDictionary) => {
 
   let month = "";
   let year = "";
-  if (
-    data["card-expiration"] &&
-    data["card-expiration"].indexOf(" / ") !== -1
-  ) {
-    const exp = data["card-expiration"].split(" / ");
-    month = exp[0] || "";
-    year = (exp[1] || "").substr(2, 2);
+  const expiration = parseExpiration(data["card-expiration"]);
+
+  if (expiration) {
+    month = expiration.month;
+    year = expiration.year;
   }
 
   const request = {

--- a/packages/globalpayments-js/src/internal/gateways/gp-api/action-tokenize.ts
+++ b/packages/globalpayments-js/src/internal/gateways/gp-api/action-tokenize.ts
@@ -1,6 +1,7 @@
 import { generateGuid } from "globalpayments-lib";
 
 import { options } from "../../lib/options";
+import parseExpiration from "../../lib/parse-expiration";
 import { IDictionary } from "../../lib/util";
 import { setGpApiHeaders } from "../../lib/set-headers";
 
@@ -24,14 +25,12 @@ export default async (url: string, env: string, data: IDictionary) => {
     request.card.cvv = data["card-cvv"];
   }
 
-  if (
-    data["card-expiration"] &&
-    data["card-expiration"].indexOf(" / ") !== -1
-  ) {
-    const exp = data["card-expiration"].split(" / ");
+  const expiration = parseExpiration(data["card-expiration"]);
+
+  if (expiration) {
     request.card = request.card || {};
-    request.card.expiry_month = exp[0] || "";
-    request.card.expiry_year = (exp[1] || "").length === 2 ? (exp[1] || "") : (exp[1] || "").substr(2, 2);
+    request.card.expiry_month = expiration.month;
+    request.card.expiry_year = expiration.year;
   }
 
   if (data["card-holder-name"]) {

--- a/packages/globalpayments-js/src/internal/gateways/heartland/action-tokenize.ts
+++ b/packages/globalpayments-js/src/internal/gateways/heartland/action-tokenize.ts
@@ -1,4 +1,5 @@
 import { IDictionary } from "../../lib/util";
+import parseExpiration from "../../lib/parse-expiration";
 
 export default async (url: string, env: string, data: IDictionary) => {
   const request: any = {
@@ -16,14 +17,12 @@ export default async (url: string, env: string, data: IDictionary) => {
     request.card.cvc = data["card-cvv"];
   }
 
-  if (
-    data["card-expiration"] &&
-    data["card-expiration"].indexOf(" / ") !== -1
-  ) {
-    const exp = data["card-expiration"].split(" / ");
+  const expiration = parseExpiration(data["card-expiration"]);
+
+  if (expiration) {
     request.card = request.card || {};
-    request.card.exp_month = exp[0] || "";
-    request.card.exp_year = exp[1] || "";
+    request.card.exp_month = expiration.month;
+    request.card.exp_year = expiration.yearFull;
   }
 
   // TODO: Properly accept encrypted track data

--- a/packages/globalpayments-js/src/internal/gateways/openedge/action-tokenize.ts
+++ b/packages/globalpayments-js/src/internal/gateways/openedge/action-tokenize.ts
@@ -1,4 +1,5 @@
 import { options } from "../../lib/options";
+import parseExpiration from "../../lib/parse-expiration";
 import { IDictionary } from "../../lib/util";
 
 export default async (url: string, env: string, data: IDictionary) => {
@@ -14,14 +15,12 @@ export default async (url: string, env: string, data: IDictionary) => {
     request.card.card_security_code = data["card-cvv"];
   }
 
-  if (
-    data["card-expiration"] &&
-    data["card-expiration"].indexOf(" / ") !== -1
-  ) {
-    const exp = data["card-expiration"].split(" / ");
+  const expiration = parseExpiration(data["card-expiration"]);
+
+  if (expiration) {
     request.card = request.card || {};
-    request.card.expiry_month = exp[0] || "";
-    request.card.expiry_year = exp[1].slice(-2) || "";
+    request.card.expiry_month = expiration.month;
+    request.card.expiry_year = expiration.year;
   }
 
   // TODO: Properly accept encrypted track data

--- a/packages/globalpayments-js/src/internal/gateways/transit/action-tokenize.ts
+++ b/packages/globalpayments-js/src/internal/gateways/transit/action-tokenize.ts
@@ -1,4 +1,5 @@
 import { options } from "../../lib/options";
+import parseExpiration from "../../lib/parse-expiration";
 import { IDictionary } from "../../lib/util";
 
 export default (url: string, enbv: string, data: IDictionary) => {
@@ -16,11 +17,10 @@ export default (url: string, enbv: string, data: IDictionary) => {
       );
     }
 
-    if (
-      data["card-expiration"] &&
-      data["card-expiration"].indexOf(" / ") !== -1
-    ) {
-      request.expirationDate = data["card-expiration"].replace(" / ", "/");
+    const expiration = parseExpiration(data["card-expiration"]);
+
+    if (expiration) {
+      request.expirationDate = `${expiration.month}/${expiration.yearFull}`;
     }
 
     return request;

--- a/packages/globalpayments-js/src/internal/lib/card.ts
+++ b/packages/globalpayments-js/src/internal/lib/card.ts
@@ -144,7 +144,12 @@ export default class Card {
     }
 
     // used for triggering the keyup event on safari
-    target.value = new ExpirationFormatter().format(value, e.type === "blur" || (e.type === "keyup" && target !== document.activeElement && isSafari));
+    target.value = new ExpirationFormatter().format(
+      value,
+      e.type === "blur" ||
+        e.type === "change" ||
+        (e.type === "keyup" && target !== document.activeElement && isSafari),
+    );
   }
 
   /**
@@ -264,8 +269,14 @@ export default class Card {
 
     const { value, target } = Card.getFieldEventData(e);
 
+    // The expiration field carries a separator. The field formats it as " / ",
+    // but a value written by the browser's AutoFill keeps whatever separator
+    // the browser used, typically a bare "/".
+    const separators =
+      target.name === CardFormFieldNames.CardExpiration ? /[\s/]/g : /\s/g;
+
     const integerRegex = /^\d+$/;
-    if (!integerRegex.test(value.replaceAll(' / ', '').replaceAll(' ', ''))) {
+    if (!integerRegex.test(value.replace(separators, ""))) {
       target.value = "";
     }
   }
@@ -1028,6 +1039,12 @@ export default class Card {
     Events.addHandler(el, "keydown", Card.restrictLength(9));
     Events.addHandler(el, "keyup", Card.formatExpiration);
     Events.addHandler(el, "blur", Card.formatExpiration);
+    // AutoFill writes the field without any keyboard event, so `change` is the
+    // only opportunity to format a value the cardholder never typed. Validity is
+    // re-tested afterwards so it reflects the formatted value rather than the
+    // raw one the `input` handler saw.
+    Events.addHandler(el, "change", Card.formatExpiration);
+    Events.addHandler(el, "change", Card.validateExpiration);
     Events.addHandler(el, "input", Card.validateExpiration);
     Events.addHandler(el, "blur", Card.validateExpiration);
     Events.addHandler(el, "blur", Card.postInstallmentFieldValidatedEvent);

--- a/packages/globalpayments-js/src/internal/lib/parse-expiration.ts
+++ b/packages/globalpayments-js/src/internal/lib/parse-expiration.ts
@@ -1,0 +1,48 @@
+/**
+ * Parsed representation of a combined `card-expiration` value.
+ */
+export interface IParsedExpiration {
+  /** Zero padded two digit month. */
+  month: string;
+  /** Two digit year. */
+  year: string;
+  /** Four digit year. */
+  yearFull: string;
+}
+
+/**
+ * Parses the value of the combined `card-expiration` hosted field.
+ *
+ * The field formats its own value as `MM / YYYY` from its `keyup` and `blur`
+ * handlers, so the tokenization paths used to look for that exact separator to
+ * decide whether an expiration was present. A value written by the browser's
+ * AutoFill never passes through those handlers and arrives as `MM/YYYY`, which
+ * left the expiration silently missing from the tokenization request.
+ *
+ * Parsing the raw value keeps tokenization independent of how the value
+ * reached the field, and of which separator the browser used.
+ *
+ * @param value Raw hosted field value
+ * @returns The parsed expiration, or `undefined` when `value` does not hold a
+ *          usable month and year
+ */
+export default (value: string): IParsedExpiration | undefined => {
+  const groups = (value || "").match(
+    /^\D*(0[1-9]|1[0-2]|[1-9])\D*(\d{4}|\d{2})\s*$/,
+  );
+
+  if (!groups) {
+    return undefined;
+  }
+
+  const month = groups[1].length === 1 ? "0" + groups[1] : groups[1];
+  const yearFull =
+    groups[2].length === 4
+      ? groups[2]
+      : new Date()
+          .getFullYear()
+          .toString()
+          .slice(0, 2) + groups[2];
+
+  return { month, year: yearFull.substr(2, 2), yearFull };
+};

--- a/packages/globalpayments-js/src/internal/requests/tokenize.ts
+++ b/packages/globalpayments-js/src/internal/requests/tokenize.ts
@@ -3,6 +3,7 @@ import buildUrl from "../lib/build-tokenization-url";
 import { typeByNumber, typeByTrack } from "../lib/card-types";
 import getGateway from "../lib/get-gateway";
 import { options } from "../lib/options";
+import parseExpiration from "../lib/parse-expiration";
 import { IDictionary } from "../lib/util";
 
 export default (data: IDictionary) => {
@@ -84,15 +85,12 @@ export default (data: IDictionary) => {
           resp.details.cardSecurityCode = !!data["card-cvv"];
         }
 
-        if (
-          data["card-expiration"] &&
-          data["card-expiration"].indexOf(" / ") !== -1
-        ) {
-          const exp = data["card-expiration"].split(" / ");
+        const expiration = parseExpiration(data["card-expiration"]);
 
+        if (expiration) {
           resp.details = resp.details || {};
-          resp.details.expiryMonth = exp[0] || "";
-          resp.details.expiryYear = exp[1] || "";
+          resp.details.expiryMonth = expiration.month;
+          resp.details.expiryYear = expiration.yearFull;
         }
 
         if (data["card-holder-name"]) {

--- a/packages/globalpayments-js/src/internal/validators/expiration.ts
+++ b/packages/globalpayments-js/src/internal/validators/expiration.ts
@@ -1,3 +1,4 @@
+import parseExpiration from "../lib/parse-expiration";
 import IValidator from "./validator";
 
 export default class Expiration implements IValidator {
@@ -49,16 +50,13 @@ export default class Expiration implements IValidator {
    * @returns A boolean indicating whether the expiration date is valid or not.
    */
   public validateDate(exp: string): boolean {
-    // Regular expression to match "MM/YYYY" format
-    const dateRegex = /^(0[1-9]|1[0-9])\/(20\d{2})$/;
+    const expiration = parseExpiration(exp);
 
-    // Remove whitespace from the expiration date string
-    const val = !exp ? '': exp.replaceAll(' ', '');
+    // Not a usable month and year
+    if (!expiration) return false;
 
-    // Check if the expiration date matches the expected format
-    if (!dateRegex.test(val)) return false;
-
-    const [month, year] = exp.split(' / ').map(Number);
+    const month = Number(expiration.month);
+    const year = Number(expiration.yearFull);
     const currentDate = new Date();
     const currentMonth = currentDate.getUTCMonth() + 1;
     const currentYear = currentDate.getFullYear();

--- a/packages/globalpayments-js/test/fixtures/gp-api/card-autofill/runner.html
+++ b/packages/globalpayments-js/test/fixtures/gp-api/card-autofill/runner.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Global Payments Examples</title>
+  </head>
+  <body>
+    <script src="/dist/globalpayments.js"></script>
+    <script src="/test/fixtures/gp-api/sha512.js"></script>
+
+    <form id="form" action="/charge" method="get">
+      <div id="cardNumber"></div>
+      <div id="cardCvv"></div>
+      <div id="cardExpiration"></div>
+      <div id="cardHolder"></div>
+      <div id="cardSubmit"></div>
+    </form>
+
+    <script>
+      const createAccessToken = async () => {
+        // !!! Never do this in production. !!!
+        // It will expose your shared secret to the outside world.
+        // We're only doing this here to simplify the tests.
+        //
+        // See `/examples/gp-api.php` for a suggested way to hash
+        // requests securely from a server-side integration.
+        // !!! Never do this in production. !!!
+
+        const appId = "q3HGIFtHPt6ivl7JXGNBsXLFpDdsFHoN";
+        const appKey = "wJUd4vJQfN23sVxG";
+        const nonce = new Date().toISOString();
+        const secret = SHA512(nonce + "" + appKey);
+
+        const resp = await fetch(
+          "https://apis-qa.globalpay.com/ucp/accesstoken",
+          {
+            body: JSON.stringify({
+              app_id: appId,
+              secret: secret,
+              grant_type: "client_credentials",
+              nonce: nonce,
+              interval_to_expire: "1_HOUR",
+              permissions: ["PMT_POST_Create_Single"],
+            }),
+            credentials: "omit",
+            headers: {
+              "Content-Type": "application/json",
+              "X-GP-Version": "2021-03-22",
+            },
+            method: "POST",
+          },
+        );
+        const json = await resp.json();
+        return json.token;
+      };
+
+      const createResults = (resp) => {
+        const el = document.createElement("input");
+        el.id = "testResult";
+        el.type = "hidden";
+        el.value = JSON.stringify(resp);
+        document.body.appendChild(el);
+      };
+
+      (async () => {
+        const accessToken = await createAccessToken();
+
+        // The hosted fields are served from the local build so a test can reach
+        // into them to write a value the way the browser's AutoFill does, while
+        // tokenization still runs against the real API.
+        GlobalPayments.configure({
+          accessToken: accessToken,
+          env: "local",
+          serviceURL: "https://apis-qa.globalpay.com",
+          enableAutocomplete: true,
+        });
+
+        const cardForm = GlobalPayments.ui.form({
+          fields: {
+            "card-number": {
+              placeholder: "•••• •••• •••• ••••",
+              target: "#cardNumber",
+            },
+            "card-expiration": {
+              placeholder: "MM / YYYY",
+              target: "#cardExpiration",
+            },
+            "card-cvv": {
+              placeholder: "•••",
+              target: "#cardCvv",
+            },
+            "card-holder-name": {
+              placeholder: "Jane Smith",
+              target: "#cardHolder",
+            },
+            submit: {
+              value: "Submit",
+              target: "#cardSubmit",
+            },
+          },
+        });
+
+        cardForm.on("card-number", "token-success", createResults);
+        cardForm.on("card-number", "token-error", createResults);
+        GlobalPayments.on("error", createResults);
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/globalpayments-js/test/integration/gp-api/autofill_spec.js
+++ b/packages/globalpayments-js/test/integration/gp-api/autofill_spec.js
@@ -1,0 +1,83 @@
+import { assertCardTokenSuccess, visit } from "../../support/helpers";
+
+// A browser AutoFill pass writes a field's value directly and dispatches only
+// `input` / `change`. It never produces a keyboard event and never focuses the
+// field, so the combined `card-expiration` field keeps whatever separator the
+// browser used instead of the " / " it formats itself with.
+//
+// Chromium does not fill cross-origin frames, so the only value it writes goes
+// into the library's own hidden relay inputs in the `card-number` frame, which
+// reach the expiration field through `set-value` and get formatted on the way
+// in. WebKit fills the real hosted field inputs directly, so the value arrives
+// unformatted. Tokenization has to cope with both.
+
+// The fixture fetches an access token before it renders, so wait for the frames
+// to hold a field before reading their contents.
+const waitForFields = () =>
+  ["#cardNumber", "#cardExpiration", "#cardCvv", "#cardHolder", "#cardSubmit"].forEach(
+    (target) => {
+      cy.get(target + " > iframe").should((frame) => {
+        expect(frame.contents().find("#secure-payment-field")).to.have.lengthOf(1);
+      });
+    },
+  );
+
+const input = (target) =>
+  cy.get(target + " > iframe").then((frame) => frame.contents().find("#secure-payment-field"));
+
+const autofill = (target, value, withChange) =>
+  input(target).then(($el) => {
+    const el = $el.get(0);
+    el.value = value;
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    if (withChange !== false) {
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  });
+
+const autofillCard = (expiration, withChange) => {
+  autofill("#cardNumber", "4111111111111111", withChange);
+  autofill("#cardExpiration", expiration, withChange);
+  autofill("#cardCvv", "123", withChange);
+  autofill("#cardHolder", "Jane Smith", withChange);
+};
+
+describe("gp-api - autofill", () => {
+  beforeEach(() => {
+    visit("gp-api/card-autofill");
+    waitForFields();
+  });
+
+  const formats = [
+    ["12/2029", "12 / 2029"],
+    ["12/29", "12 / 2029"],
+    ["1229", "12 / 2029"],
+    ["12-2029", "12 / 2029"],
+    ["7/29", "07 / 2029"],
+  ];
+
+  formats.forEach(([value, formatted]) => {
+    it(`tokenizes an expiration autofilled as "${value}"`, () => {
+      autofillCard(value);
+
+      input("#cardExpiration").should("have.value", formatted);
+      input("#cardExpiration").should("have.class", "valid");
+
+      input("#cardSubmit").click({ force: true });
+
+      cy.get("#testResult").then(assertCardTokenSuccess);
+    });
+  });
+
+  it("tokenizes an expiration the field never had a chance to format", () => {
+    autofillCard("12/2029", false);
+
+    // Without a `change` event the value is still unformatted, which must not
+    // stop the expiration from reaching the tokenization request.
+    input("#cardExpiration").should("have.value", "12/2029");
+
+    input("#cardSubmit").click({ force: true });
+
+    cy.get("#testResult").then(assertCardTokenSuccess);
+  });
+});


### PR DESCRIPTION
Fixes #136.

## Problem

Tokenization only emitted `expiry_month` / `expiry_year` when the raw `card-expiration` value contained the literal `" / "`. That separator comes from `Card.formatExpiration`, which was bound only to `keyup` and `blur`. Browser AutoFill writes a value and fires `input` / `change`, never a keyboard event, so an autofilled expiration kept the browser's separator (`12/2029`) and was silently left out of the request. GP API answered `MANDATORY_DATA_MISSING: expiry_month`.

Nothing stopped the submit, because `ExpirationValidator.validate` splits on `/` and accepted the same value the serializer rejected. The field went green and only the gateway complained.

Chromium does not fill cross-origin frames, so its only write goes into the hidden relay inputs in the `card-number` frame, which reach the expiration field through `set-value` and get formatted by the synthetic `keyup` it fires. WebKit fills the real inputs directly, which is why this showed up on Safari.

## Change

`parseExpiration` reads month and year out of the raw value instead of pattern matching on the separator, and returns both a two digit and a four digit year so each gateway keeps the shape it already sent. All seven tokenization paths use it.

On the field itself, `formatExpiration` and `validateExpiration` now also run on `change`, so an autofilled value is corrected on screen and its validity reflects the corrected value rather than the raw one the `input` handler saw. `restrictNumericOnInput` no longer clears the expiration field when its only non-digit character is the separator.

`validateDate` uses the same parser. It previously ran `exp.split(' / ').map(Number)` on values that may contain no `" / "`, producing `NaN` and skipping every date check, so `validateDate("01/2020")` returned `true` for an expired card. Its regex also accepted months 13 to 19.

## Tests

`test/integration/gp-api/autofill_spec.js` writes field values the way AutoFill does, then tokenizes against the API.

Without the change, 6 of 6 fail:

```
1) tokenizes an expiration autofilled as "12/2029"
   expected '<input.card-expiration.possibly-valid.valid>' to have value '12 / 2029',
   but the value was '12/2029'
6) tokenizes an expiration the field never had a chance to format
   AssertionError: expected undefined to be truthy      // no paymentReference
```

With it, 6 of 6 pass:

```
✓ tokenizes an expiration autofilled as "12/2029"
✓ tokenizes an expiration autofilled as "12/29"
✓ tokenizes an expiration autofilled as "1229"
✓ tokenizes an expiration autofilled as "12-2029"
✓ tokenizes an expiration autofilled as "7/29"
✓ tokenizes an expiration the field never had a chance to format
6 passing
```

The last case dispatches `input` without `change`, so the field value is never formatted. It passes because tokenization no longer depends on the field's formatting, which matters if WebKit turns out not to fire `change` either.

`experience/formatting_spec.js`, `type-detection_spec.js` and `attributes_spec.js` still pass. `validation_spec.js` fails on `validates expiration dates` both before and after this change: it hardcodes `12 / 2025`, which expired in January. Not addressed here.

The new fixture uses `env: "local"` with `serviceURL` so the frames load from the local build. The existing `gp-api` fixtures point at `js-qa.np-hpp.globalpay.com/5.0.1/`, which returns 404, so their frames never render.

## Behaviour changes to review

For values the existing formatter produces, 25 of 35 gateway and value combinations are byte identical. Ten differ, all on a two digit year (`12 / 29`), which reaches a serializer when the field has not been blurred:

| gateway | before | after |
|---|---|---|
| genius, gp-ecom | `year: ""` | `year: "29"` |
| heartland, `details` | `2029` or `29` depending on blur | `2029` |
| transit | `12/29` | `12/2029` |

Genius and GP eCom ran `substr(2, 2)` on `"29"` and sent an empty year, so that pair is a fix. The four digit normalization for Heartland, TransIT and the `details` response is intentional and matches what those paths already sent once the field had been blurred, but TransIT's `expirationDate` format is worth a second opinion.

`CHANGELOG.md` is untouched, since version sections are added by the release process.
